### PR TITLE
Partially automate updates with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,15 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["/Dockerfile$"],
+      "matchStrings": [
+        "ARG LOLMINER_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "Lolliedieb/lolMiner-releases",
+    }
+  ],
 }


### PR DESCRIPTION
This partially addresses: https://github.com/compscidr/lolminer-docker/issues/28

however, it still doesn't update the build and deploy workflows - it only updates the default build version in the `Dockerfile`, however its a starting point. It should at least make a PR everytime the version changes which should notify me to make the manual changes myself.